### PR TITLE
Add QCS8550

### DIFF
--- a/apps/android/ChatApp/src/main/assets/htp_config/qualcomm-snapdragon-8-gen2.json
+++ b/apps/android/ChatApp/src/main/assets/htp_config/qualcomm-snapdragon-8-gen2.json
@@ -1,0 +1,21 @@
+{
+    "devices": [
+        {
+            "soc_model": 43,
+            "dsp_arch": "v73",
+            "cores": [
+                {
+                    "core_id": 0,
+                    "perf_profile": "burst",
+                    "rpc_control_latency": 100
+                }
+            ]
+        }
+    ],
+    "memory": {
+        "mem_type": "shared_buffer"
+    },
+    "groupContext": {
+        "share_resources": true
+    }
+}

--- a/apps/android/ChatApp/src/main/java/com/quicinc/chatapp/MainActivity.java
+++ b/apps/android/ChatApp/src/main/java/com/quicinc/chatapp/MainActivity.java
@@ -91,6 +91,7 @@ public class MainActivity extends AppCompatActivity {
             HashMap<String, String> supportedSocModel = new HashMap<>();
             supportedSocModel.putIfAbsent("SM8750", "qualcomm-snapdragon-8-elite.json");
             supportedSocModel.putIfAbsent("SM8650", "qualcomm-snapdragon-8-gen3.json");
+            supportedSocModel.putIfAbsent("QCS8550", "qualcomm-snapdragon-8-gen2.json");
 
             String socModel = android.os.Build.SOC_MODEL;
             if (!supportedSocModel.containsKey(socModel)) {


### PR DESCRIPTION
Add QCS8550

.bin create by command:
python -m qai_hub_models.models.llama_v3_2_3b_chat_quantized.export --context-length 2048 --device "Samsung Galaxy S23" --output-dir genie_bundle

Test with Qualcomm AIM RDK QCS8550, Nexretail, Taiwan, 16G Ram
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/d9eb281b-214e-462d-bb82-21b1b1d29207">

