### PR TITLE
Updated the versions of torch and torchvision

### DIFF
--- a/tutorials/llm_on_genie/README.md
+++ b/tutorials/llm_on_genie/README.md
@@ -186,7 +186,8 @@ The export command below may take 4-6 hours. It takes an additional 1-2 hours
 on PyTorch versions earlier than 2.4.0. We recommend upgrading PyTorch first:
 
 ```bash
-pip install torch==2.4.0
+pip install torch==2.2.2
+pip install torchvision==0.17.2
 ```
 
 This version is not yet supported in general by AI Hub Models but will work


### PR DESCRIPTION
Only this version of torch and torchvision allows the model conversion. Any other versions graeter than 2.3 will break the model build process.